### PR TITLE
deals with overlaps in some weird gene structures.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -467,6 +467,7 @@ return declare( JBrowsePlugin,
                 var pairTypes = pair.map(function(o) {return o.type.toLowerCase();});
                 var CDSObjIndx = pairTypes.indexOf('cds');
                 var exonObjIndx = pairTypes.indexOf('exon');
+                if (CDSObjIndx == -1 || exonObjIndx== -1) { return; }
           
                 if (pair[0].start == pair[1].start && pair[0].end == pair[1].end) {
                     var discard_name = pair[exonObjIndx].id;


### PR DESCRIPTION
using Maker, we could have two exons or two cds that overlap. exonObjIndx and CDSObjIndx could then be equal to -1, and the plugin fails.

> 1       maker   exon    1591    1852    .       +       .       ID=GENE.1:1;Parent=GENE.1
1       maker   CDS     1591    1852    .       +       0       ID=GENE.1:cds;Parent=GENE.1
1       maker   mRNA    1591    7018    .       +       .       ID=GENE.1;Parent=GENE
1       maker   gene    1591    7018    .       +       .       ID=GENE;Name=GENE
1       maker   CDS     2091    2220    .       +       2       ID=GENE.1:cds;Parent=GENE.1
1       maker   exon    2091    2220    .       +       .       ID=GENE.1:2;Parent=GENE.1
1       maker   CDS     4636    4743    .       +       1       ID=GENE.1:cds;Parent=GENE.1
1       maker   exon    4636    4743    .       +       .       ID=GENE.1:3;Parent=GENE.1
1       maker   CDS     4847    4949    .       +       1       ID=GENE.1:cds;Parent=GENE.1
1       maker   exon    4847    4949    .       +       .       ID=GENE.1:4;Parent=GENE.1
1       maker   CDS     5024    5188    .       +       0       ID=GENE.1:cds;Parent=GENE.1
1       maker   exon    5024    6209    .       +       .       ID=GENE.1:5;Parent=GENE.1
1       maker   three_prime_UTR 5189    6209    .       +       .       ID=GENE.1:three_prime_utr;Parent=GENE.1
1       maker   three_prime_UTR 6547    6679    .       +       .       ID=GENE.1:three_prime_utr;Parent=GENE.1
1       maker   exon    6547    6679    .       +       .       ID=GENE.1:6;Parent=GENE.1
1       maker   exon    6768    7018    .       +       .       ID=GENE.1:7;Parent=GENE.1
1       maker   three_prime_UTR 6768    7018    .       +       .       ID=GENE.1:three_prime_utr;Parent=GENE.1

